### PR TITLE
Update cpu architectures in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -58,7 +58,7 @@ body:
     label: Which CPU architecture are you running this on?
     options:
       - x86_64/AMD64
-      - Apple M1/M2
+      - Apple "M" Series
       - ARM64/AArch64
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -58,7 +58,7 @@ body:
     label: Which CPU architecture are you running this on?
     options:
       - x86_64/AMD64
-      - Apple "M" Series
+      - Apple M-Series
       - ARM64/AArch64
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -57,8 +57,9 @@ body:
   attributes:
     label: Which CPU architecture are you running this on?
     options:
-      - 64-bit(x86_64)
+      - x86_64/AMD64
       - Apple M1/M2
+      - ARM64/AArch64
   validations:
     required: false
 - type: textarea


### PR DESCRIPTION
From a discussion in a Pulsar issue, we offer ARM64 binaries but have no option to identify it in the issue template.

This PR renames the ambiguous "64 bit" option to the two common x86_64 names as well as adding and doing the same for ARM 64. Apple M1/2 not touched even though it *is* ARM it is still seen as separate by the community at large and some macOS users may not know it is "just" ARM.